### PR TITLE
Make sure non .py files are included in source distribution

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,9 @@
+include README.rst
+include CHANGELOG.md
+include LICENSE.txt
+include requirements.txt
+include dev-requirements.txt
+include linguistica/VERSION
+include linguistica/gui/*
+include linguistica/datasets/*
+include linguistica/tests/data/*

--- a/setup.py
+++ b/setup.py
@@ -32,9 +32,12 @@ setup(name='linguistica',
       install_requires=requirements,
 
       package_data={
-          'linguistica': ['VERSION', 'gui/d3.min.js',
-                          'gui/lxa_splash_screen.png',
-                          'datasets/*.txt', 'datasets/*.dx1'],
+          'linguistica': [
+              'VERSION',
+              'gui/*',
+              'datasets/*',
+              'tests/data/*',
+          ],
       },
 
       zip_safe=False,


### PR DESCRIPTION
To ensure all non `.py` files (e.g., metadata, test data files) are included in source distribution, this PR adds `MANIFEST.in` and updates `setup.py`. There's always something to learn about Python packaging...

@JohnAGoldsmith It's time for your approval stamp again.